### PR TITLE
Change .m2 mountpoint, set locale to utf_8 because of test failures, …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM fedora
 RUN dnf -y install java-1.8.0-openjdk-devel git which wget zip unzip svn tree iputils iproute net-tools maven vim-enhanced
 RUN dnf -y update
 
-RUN useradd builder
+RUN useradd -m builder #add user with home directory
 ADD bashrc /home/builder/.bashrc
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 RUN echo "root:docker" | chpasswd
 USER builder

--- a/bashrc
+++ b/bashrc
@@ -2,8 +2,6 @@ export MAVEN_HOME=/maven
 export HOME=/workspace
 export JAVA_HOME=/java
 
-export M2_HOME=
-
 export PATH=${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${PATH}
 
 # colors

--- a/perseus
+++ b/perseus
@@ -7,7 +7,7 @@ readonly DOCKER_USER=${DOCKER_USER:-'builder'}
 readonly BUILD_COMMAND=${2:-'/bin/bash'}
 
 if [ -z "${WORKSPACE}" ]; then
-  echo "Not Provided workspace to mount and build from"
+  echo "No provided workspace to mount and build from. Abort."
   exit 1
 fi
 

--- a/perseus
+++ b/perseus
@@ -7,7 +7,7 @@ readonly DOCKER_USER=${DOCKER_USER:-'builder'}
 readonly BUILD_COMMAND=${2:-'/bin/bash'}
 
 if [ -z "${WORKSPACE}" ]; then
-  echo "Provided workspace to mount and build from"
+  echo "Not Provided workspace to mount and build from"
   exit 1
 fi
 
@@ -20,7 +20,7 @@ readonly DOCKER_IMAGE=${DOCKER_IMAGE:-'builder:latest'}
 
 readonly DOCKER_JAVAZI_MOUNT=${DOCKER_JAVAZI_MOUNT:-'/usr/share/javazi-1.8/:/usr/share/javazi-1.8/:ro'}
 readonly DOCKER_WORKSPACE_MOUNT="${WORKSPACE}:/workspace:rw"
-readonly DOCKER_MAVEN_M2_HOME_MOUNT="${M2_HOME}:/workspace/.m2/:rw"
+readonly DOCKER_MAVEN_M2_HOME_MOUNT="${M2_HOME}:/home/builder/.m2/:rw"
 readonly DOCKER_JAVA_HOME_MOUNT="${JAVA_HOME}:/java:ro"
 
 if [ "$(getenforce | grep -e Enforcing -c)" -gt 0 ]; then


### PR DESCRIPTION
…fix warning about missing workspace.

The .m2 from /workspace/.m2 wasn't being used, even the $HOME was changed it was still looking into /home/builder/.m2 so I changed the mount point. Do you think it is ok ?

Another thing is that fedora docker image has locale set to POSIX out of the box. Therefore when I tried to build wildfly-core in the image it was failing because of this test "org.jboss.as.test.integration.management.cli.AppendTestCase" which is testing file names with special characters. So I added the setting of the locale to UTF_8 and it now works.


